### PR TITLE
fix for checking if user/print.css exists

### DIFF
--- a/main.php
+++ b/main.php
@@ -515,7 +515,7 @@ if ($monobook_action === "print"){
   //      thing! BTW: good text about this: http://is.gd/5MyG5
   echo  "<link rel=\"stylesheet\" media=\"all\" type=\"text/css\" href=\"".DOKU_TPL."static/css/print.css\" />\n"
        ."<link rel=\"stylesheet\" media=\"all\" type=\"text/css\" href=\"".DOKU_TPL."static/3rd/wikipedia/commonPrint.css\" />\n";
-  if (file_exists(DOKU_TPL."user/print.css")){
+  if (file_exists(DOKU_TPLINC."user/print.css")){
       echo "<link rel=\"stylesheet\" media=\"all\" type=\"text/css\" href=\"".DOKU_TPL."user/print.css\" />\n";
   }
 }


### PR DESCRIPTION
The file user/print.css is not found as the path in DOKU_TPL isn't correct for the php function file_exists()
For the html link it works perfectly fine. See also this fix: https://github.com/arsava/dokuwiki-template-monobook/commit/11d1b4a4bce42dfd5cf437e7618a3cb54d900ec9
