### PR TITLE
Use dw2pdf for export instead broken html2pdf

### DIFF
--- a/conf/tabs.php
+++ b/conf/tabs.php
@@ -142,10 +142,10 @@ if (empty($conf["useacl"]) || //are there any users?
     }
 
 
-    //html2pdf plugin: export tab (thanks to Luigi Micco <l.micco@tiscali.it>)
-    //see <https://www.dokuwiki.org/plugin:html2pdf> for info
-    if (file_exists(DOKU_PLUGIN."html2pdf/action.php") &&
-        !plugin_isdisabled("html2pdf")){
+    //dw2pdf plugin: export tab (thanks to Luigi Micco <l.micco@tiscali.it>)
+    //see <https://www.dokuwiki.org/plugin:dw2pdf> for info
+    if (file_exists(DOKU_PLUGIN."dw2pdf/action.php") &&
+        !plugin_isdisabled("dw2pdf")){
         $_monobook_tabs["tab-export-pdf"]["text"]     = $lang["monobook_tab_exportpdf"];
         $_monobook_tabs["tab-export-pdf"]["href"]     = wl(cleanID(getId()), array("do" => "export_pdf"), false, "&");
         $_monobook_tabs["tab-export-pdf"]["nofollow"] = true;


### PR DESCRIPTION
Since html2pdf appears to be broken and not updated since 2009, we
should use the current dw2pdf

See:
https://www.dokuwiki.org/plugin:html2pdf
https://www.dokuwiki.org/plugin:dw2pdf
