### PR TITLE
Fix navigation for restricted users

### DIFF
--- a/conf/boxes.php
+++ b/conf/boxes.php
@@ -81,7 +81,7 @@ if (empty($conf["useacl"]) || //are there any users?
         if (empty($conf["useacl"]) ||
             auth_quickaclcheck(cleanID($nav_location)) >= AUTH_READ){ //current user got access?
             //get the rendered content of the defined wiki article to use as custom navigation
-            $interim = tpl_include_page($nav_location, false);
+            $interim = tpl_include_page(cleanID($nav_location), false);
             if ($interim === "" ||
                 $interim === false){
                 //creation/edit link if the defined page got no content


### PR DESCRIPTION
"monobook_fillplaceholder" was shown for non admin users in the navigation box. When clicking to create the page, the navigation was shown, so permissions are correct and page really exist.